### PR TITLE
Update to Joomla gitignore files

### DIFF
--- a/Joomla.gitignore
+++ b/Joomla.gitignore
@@ -64,6 +64,12 @@
 /administrator/language/en-GB/en-GB.plg_finder_tags.sys.ini
 /administrator/language/en-GB/en-GB.plg_finder_weblinks.ini
 /administrator/language/en-GB/en-GB.plg_finder_weblinks.sys.ini
+/administrator/language/en-GB/en-GB.plg_installer_folderinstaller.ini
+/administrator/language/en-GB/en-GB.plg_installer_folderinstaller.sys.ini
+/administrator/language/en-GB/en-GB.plg_installer_packageinstaller.ini
+/administrator/language/en-GB/en-GB.plg_installer_packageinstaller.sys.ini
+/administrator/language/en-GB/en-GB.plg_installer_urlinstaller.ini
+/administrator/language/en-GB/en-GB.plg_installer_urlinstaller.sys.ini
 /administrator/language/en-GB/en-GB.plg_installer_webinstaller.ini
 /administrator/language/en-GB/en-GB.plg_installer_webinstaller.sys.ini
 /administrator/language/en-GB/en-GB.plg_quickicon_joomlaupdate.ini
@@ -72,6 +78,8 @@
 /administrator/language/en-GB/en-GB.plg_search_tags.sys.ini
 /administrator/language/en-GB/en-GB.plg_system_languagecode.ini
 /administrator/language/en-GB/en-GB.plg_system_languagecode.sys.ini
+/administrator/language/en-GB/en-GB.plg_system_stats.ini
+/administrator/language/en-GB/en-GB.plg_system_stats.sys.ini
 /administrator/language/en-GB/en-GB.plg_twofactorauth_totp.ini
 /administrator/language/en-GB/en-GB.plg_twofactorauth_totp.sys.ini
 /administrator/language/en-GB/en-GB.plg_twofactorauth_yubikey.ini
@@ -199,6 +207,8 @@
 /administrator/language/en-GB/en-GB.plg_editors-xtd_article.sys.ini
 /administrator/language/en-GB/en-GB.plg_editors-xtd_image.ini
 /administrator/language/en-GB/en-GB.plg_editors-xtd_image.sys.ini
+/administrator/language/en-GB/en-GB.plg_editors-xtd_module.ini
+/administrator/language/en-GB/en-GB.plg_editors-xtd_module.sys.ini
 /administrator/language/en-GB/en-GB.plg_editors-xtd_pagebreak.ini
 /administrator/language/en-GB/en-GB.plg_editors-xtd_pagebreak.sys.ini
 /administrator/language/en-GB/en-GB.plg_editors-xtd_readmore.ini
@@ -237,6 +247,8 @@
 /administrator/language/en-GB/en-GB.plg_system_remember.sys.ini
 /administrator/language/en-GB/en-GB.plg_system_sef.ini
 /administrator/language/en-GB/en-GB.plg_system_sef.sys.ini
+/administrator/language/en-GB/en-GB.plg_system_updatenotification.ini
+/administrator/language/en-GB/en-GB.plg_system_updatenotification.sys.ini
 /administrator/language/en-GB/en-GB.plg_user_contactcreator.ini
 /administrator/language/en-GB/en-GB.plg_user_contactcreator.sys.ini
 /administrator/language/en-GB/en-GB.plg_user_joomla.ini
@@ -251,6 +263,7 @@
 /administrator/language/en-GB/index.html
 /administrator/language/overrides/*
 /administrator/language/index.html
+/administrator/logs/index.html
 /administrator/manifests/*
 /administrator/modules/mod_custom/*
 /administrator/modules/mod_feed/*
@@ -289,6 +302,7 @@
 /components/com_finder/*
 /components/com_mailto/*
 /components/com_media/*
+/components/com_modules/*
 /components/com_newsfeeds/*
 /components/com_search/*
 /components/com_users/*
@@ -407,6 +421,7 @@
 /libraries/idna_convert/*
 /libraries/joomla/*
 /libraries/legacy/*
+/libraries/php-encryption/*
 /libraries/phpass/*
 /libraries/phpmailer/*
 /libraries/phputf8/*
@@ -431,9 +446,11 @@
 /media/media/*
 /media/mod_languages/*
 /media/overrider/*
+/media/plg_captcha_recaptcha/*
 /media/plg_quickicon_extensionupdate/*
 /media/plg_quickicon_joomlaupdate/*
 /media/plg_system_highlight/*
+/media/plg_system_stats/*
 /media/system/*
 /media/index.html
 /modules/mod_articles_archive/*
@@ -488,6 +505,7 @@
 /plugins/editors/index.html
 /plugins/editors-xtd/article/*
 /plugins/editors-xtd/image/*
+/plugins/editors-xtd/module/*
 /plugins/editors-xtd/pagebreak/*
 /plugins/editors-xtd/readmore/*
 /plugins/editors-xtd/index.html
@@ -522,8 +540,10 @@
 /plugins/system/p3p/*
 /plugins/system/redirect/*
 /plugins/system/remember/*
+/plugins/system/stats/*
 /plugins/system/sef/*
 /plugins/system/index.html
+/plugins/system/updatenotification/*
 /plugins/twofactorauth/*
 /plugins/user/contactcreator/*
 /plugins/user/example/*


### PR DESCRIPTION
**Reasons for making this change:**

Additional files in Joomla that need to be ignored

**Links to documentation supporting these rule changes:** 

https://github.com/joomla/joomla-cms/releases

included updates to Joomla 3.5, 3.5.1 and 3.6
